### PR TITLE
FIX: Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ using Jupiter;
 
 using (var memoryModule = new MemoryModule(processName))
 {
-    var memoryModule = new MemoryModule(processName);
-
     // Allocate a region of virtual memory in the process
 
     var regionAddress = memoryModule.AllocateVirtualMemory(sizeof(int), MemoryProtection.ReadWrite);


### PR DESCRIPTION
You cannot create a variable when you've already assigned a variable with the same name before that. I presume this was a typo.